### PR TITLE
Android undefs

### DIFF
--- a/stk.cpp
+++ b/stk.cpp
@@ -64,6 +64,15 @@
  #pragma clang diagnostic ignored "-Wtautological-compare"
 #endif
 
+#if JUCE_ANDROID
+
+  // Stk.h defines stk::swap16/32/64.  This conflicts with macros in <sys/endian.h> on Android. Workaround: undefine them in the stk.h juce module header
+  #pragma message ("undefining swap16/32/64 macros to avoid conflict with stk header")
+  #undef swap16
+  #undef swap32
+  #undef swap64
+#endif
+
 #if JUCE_MSVC
  #pragma warning (push)
  #pragma warning (disable: 4127 4702 4244 4305 4100 4996 4309)

--- a/stk.cpp
+++ b/stk.cpp
@@ -64,15 +64,6 @@
  #pragma clang diagnostic ignored "-Wtautological-compare"
 #endif
 
-#if JUCE_ANDROID
-
-  // Stk.h defines stk::swap16/32/64.  This conflicts with macros in <sys/endian.h> on Android. Workaround: undefine them in the stk.h juce module header
-  #pragma message ("undefining swap16/32/64 macros to avoid conflict with stk header")
-  #undef swap16
-  #undef swap32
-  #undef swap64
-#endif
-
 #if JUCE_MSVC
  #pragma warning (push)
  #pragma warning (disable: 4127 4702 4244 4305 4100 4996 4309)

--- a/stk.h
+++ b/stk.h
@@ -53,16 +53,6 @@
  #define __LITTLE_ENDIAN__
 #endif
 
-#if JUCE_ANDROID
-
-  #include <sys/endian.h>
-  // Stk.h defines stk::swap16/32/64.  This conflicts with macros in <sys/endian.h> on Android. Workaround: undefine them in the stk.h juce module header
-  #pragma message ("undefining swap16/32/64 macros to avoid conflict with stk header")
-  #undef swap16
-  #undef swap32
-  #undef swap64
-#endif
-
 #if JUCE_MAC
  #define __MACOSX_CORE__
 #endif

--- a/stk.h
+++ b/stk.h
@@ -53,6 +53,16 @@
  #define __LITTLE_ENDIAN__
 #endif
 
+#if JUCE_ANDROID
+
+  #include <sys/endian.h>
+  // Stk.h defines stk::swap16/32/64.  This conflicts with macros in <sys/endian.h> on Android. Workaround: undefine them in the stk.h juce module header
+  #pragma message ("undefining swap16/32/64 macros to avoid conflict with stk header")
+  #undef swap16
+  #undef swap32
+  #undef swap64
+#endif
+
 #if JUCE_MAC
  #define __MACOSX_CORE__
 #endif

--- a/stk/Stk.h
+++ b/stk/Stk.h
@@ -7,6 +7,15 @@
 #include <vector>
 #include <cstdlib>
 
+#if JUCE_ANDROID
+  #include <sys/endian.h>
+  // Stk.h defines stk::swap16/32/64.  This conflicts with macros in <sys/endian.h> on Android. Workaround: undefine them in the stk.h juce module header
+  #pragma message ("undefining swap16/32/64 macros to avoid conflict with stk header")
+  #undef swap16
+  #undef swap32
+  #undef swap64
+#endif
+
 /*! \namespace stk
     \brief The STK namespace.
 


### PR DESCRIPTION
Realised I needed to add the undef's to the `stk_module/stk/Stk.h` header, seems to be the only place it made a difference.  
